### PR TITLE
Bootstrap w/ pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 About wincertstore
 ==================
 
-Home: https://bitbucket.org/tiran/wincertstore
+Home: https://pypi.org/project/wincertstore/
 
-Package license: PSF 2
+Package license: PSF-2.0
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/wincertstore-feedstock/blob/master/LICENSE.txt)
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,4 @@
+:: use bootstrapped pip to install wincertstore
+:: without depending on installed pip
+set PYTHONPATH=%cd%\pip_wheel;%cd%\setuptools_wheel
+%PYTHON% -m pip install .\wincertstore --ignore-installed --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ test:
     - wincertstore
 
 about:
-  home: https://bitbucket.org/tiran/wincertstore
+  home: https://pypi.org/project/wincertstore/
   license: PSF-2.0
   license_file: LICENSE
   summary: Python module to extract CA and CRL certs from Windows' cert store (ctypes based).

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,28 @@
 {% set version = "0.2" %}
 
+{% set pip_version = "20.2.3" %}
+{% set setuptools_version = "49.6.0" %}
+
 package:
   name: wincertstore
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/w/wincertstore/wincertstore-{{ version }}.zip
-  sha256: 780bd1557c9185c15d9f4221ea7f905cb20b93f7151ca8ccaed9714dce4b327a
+  - url: https://pypi.io/packages/source/w/wincertstore/wincertstore-{{ version }}.zip
+    sha256: 780bd1557c9185c15d9f4221ea7f905cb20b93f7151ca8ccaed9714dce4b327a
+    folder: wincertstore
+  # bootstrap pip and setuptools to avoid circular dependency
+  # but without losing metadata
+  - url: https://pypi.io/packages/py2.py3/p/pip/pip-{{ pip_version }}-py2.py3-none-any.whl
+    sha256: 0f35d63b7245205f4060efe1982f5ea2196aa6e5b26c07669adcf800e2542026
+    folder: pip_wheel
+  - url: https://pypi.io/packages/py3/s/setuptools/setuptools-{{ setuptools_version }}-py3-none-any.whl
+    sha256: 4dd5bb0a0a0cff77b46ca5dd3a84857ee48c83e8223886b556613c724994073f
+    folder: setuptools_wheel
 
 build:
   number: 1004
   skip: true  # [not win]
-  script: {{ PYTHON }} setup.py install
 
 requirements:
   host:
@@ -26,7 +37,7 @@ test:
 about:
   home: https://pypi.org/project/wincertstore/
   license: PSF-2.0
-  license_file: LICENSE
+  license_file: wincertstore/LICENSE
   summary: Python module to extract CA and CRL certs from Windows' cert store (ctypes based).
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     folder: setuptools_wheel
 
 build:
-  number: 1004
+  number: 1005
   skip: true  # [not win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ test:
 
 about:
   home: https://bitbucket.org/tiran/wincertstore
-  license: PSF 2
+  license: PSF-2.0
   license_file: LICENSE
   summary: Python module to extract CA and CRL certs from Windows' cert store (ctypes based).
 


### PR DESCRIPTION
To ensure we build `wincertstore` with `pip` as we do with other packages (including `certifi`) while avoiding a circular dependency (as `setuptools` depends on `wincertstore`), download the `pip` and `setuptools` wheels and use them to install `wincertstore`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/certifi-feedstock/pull/47

cc @ocefpaf